### PR TITLE
Add `test` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "predev": "docker compose -f docker-compose.dev.yml up -d",
     "prepare": "husky install",
     "prestart": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "playwright test -g test.ts"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [


### PR DESCRIPTION
- Uses `playwright` as runner
- Requires convention `*.spec.ts` === e2e and `*.test.ts` === unit/integration

The cool thing here is that for the integration tests we can still run it against a testnet because playwright will spin up the FE and the anvil testnet.